### PR TITLE
Fix incorrect chat handler import

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -2,7 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import { config } from 'dotenv';
 import { saveMessage, getRecentMessages } from './db.js';
-import { handleChat } from './chat.js';
+import { handleChat } from './backend.chat.js';
 import { v4 as uuidv4 } from 'uuid';
 
 config();


### PR DESCRIPTION
## Summary
- fix the server import to use `backend.chat.js`

## Testing
- `node -e "import('./backend/index.js').catch(e=>console.error('Error:',e.message));"` *(fails: Cannot find package 'express' because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684144def02c832b9ae7c750cdb348ce