### PR TITLE
Add Albert assistant chatbot with React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # AI Chat Starter
 
-This repository is a simple example of a full‑stack project using GPT‑4o.
-It contains a minimal Express backend and a small React frontend.
+This repository contains "Albert", a simple multilingual chatbot that uses the
+OpenAI Assistants API (GPT‑4o) through an Express backend and a small React
+frontend.
 
 ```
-/backend   Node.js server exposing `/api/chat`
+/backend   Node.js server exposing `/chat`
 /frontend  React application built with Vite
 ```
 
@@ -21,7 +22,7 @@ cd ../frontend && npm install
 
 ```bash
 cp ../backend/env.example ../backend/.env
-# edit backend/.env and set OPENAI_API_KEY
+# edit backend/.env and set OPENAI_API_KEY and ASSISTANT_ID
 ```
 
 3. Start both services for development:
@@ -32,9 +33,9 @@ cd backend && npm start
 cd frontend && npm run dev
 ```
 
-The frontend will send requests to `http://localhost:3001/api/chat` by default.
+The frontend will send requests to `http://localhost:3001/chat` by default.
 
 ## Deploy
 
 Deploy the backend and frontend on your preferred platform as two separate services.
-Remember to set the `OPENAI_API_KEY` environment variable in the backend.
+Remember to set the `OPENAI_API_KEY` and `ASSISTANT_ID` environment variables in the backend.

--- a/backend/env.example
+++ b/backend/env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=your-openai-api-key
+ASSISTANT_ID=your-assistant-id

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import { config } from 'dotenv';
 import { OpenAI } from 'openai';
+import fs from 'fs';
 
 config();
 
@@ -11,20 +12,91 @@ app.use(express.json());
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-app.post('/api/chat', async (req, res) => {
-  const { message } = req.body;
+// load scenarios from local txt file
+const scenariosFile = new URL('./scenarios/albert_scenarios_multilingual.txt', import.meta.url);
+const scenarios = {};
+let currentLang = 'en';
+for (const line of fs.readFileSync(scenariosFile, 'utf8').split(/\r?\n/)) {
+  if (line.startsWith('[') && line.endsWith(']')) {
+    currentLang = line.slice(1, -1);
+    scenarios[currentLang] = [];
+  } else if (line.trim()) {
+    if (!scenarios[currentLang]) scenarios[currentLang] = [];
+    scenarios[currentLang].push(line.trim());
+  }
+}
+
+const sessions = {};
+
+function detectLang(text) {
+  if (/[\u0590-\u05FF]/.test(text)) return 'he';
+  if (/[\u0600-\u06FF]/.test(text)) return 'ar';
+  return 'en';
+}
+
+function nextSessionId() {
+  return Math.random().toString(36).slice(2);
+}
+
+const assistantId = process.env.ASSISTANT_ID;
+
+app.post('/chat', async (req, res) => {
+  let { message, session_id } = req.body;
   if (!message) return res.status(400).json({ error: 'Missing message' });
+
+  // create new session if needed
+  if (!session_id || !sessions[session_id]) {
+    session_id = session_id || nextSessionId();
+    const lang = detectLang(message);
+    const thread = await openai.beta.threads.create();
+    sessions[session_id] = {
+      threadId: thread.id,
+      lang,
+      scenarioIndex: 0,
+      interactions: 0
+    };
+  }
+
+  const session = sessions[session_id];
   try {
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [{ role: 'user', content: message }],
-      temperature: 0.7,
-      max_tokens: 200
+    await openai.beta.threads.messages.create(session.threadId, {
+      role: 'user',
+      content: message
     });
-    res.json({ response: completion.choices[0].message.content.trim() });
+
+    const scenarioList = scenarios[session.lang] || scenarios['en'] || [];
+    const scenarioText = scenarioList[session.scenarioIndex] || '';
+
+    const run = await openai.beta.threads.runs.create(session.threadId, {
+      assistant_id: assistantId,
+      instructions: scenarioText,
+      model: 'gpt-4o'
+    });
+
+    let status = run.status;
+    while (status === 'queued' || status === 'in_progress') {
+      await new Promise((r) => setTimeout(r, 1000));
+      const rStatus = await openai.beta.threads.runs.retrieve(session.threadId, run.id);
+      status = rStatus.status;
+    }
+
+    if (status !== 'completed') {
+      throw new Error('Run failed');
+    }
+
+    const list = await openai.beta.threads.messages.list(session.threadId, { limit: 1 });
+    const assistantMsg = list.data[0]?.content?.[0]?.text?.value || 'Sorry, I had trouble responding.';
+
+    session.interactions += 1;
+    if (session.interactions >= 3) {
+      session.interactions = 0;
+      session.scenarioIndex = (session.scenarioIndex + 1) % scenarioList.length;
+    }
+
+    res.json({ response: assistantMsg.trim(), session_id });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to generate response' });
+    res.status(500).json({ response: 'An error occurred.', session_id });
   }
 });
 

--- a/backend/scenarios/albert_scenarios_multilingual.txt
+++ b/backend/scenarios/albert_scenarios_multilingual.txt
@@ -1,0 +1,8 @@
+[en]
+Welcome! I'm Albert, here to help you improve cultural competence in teaching.
+How do you address diversity in your classroom?
+What challenges have you faced when adapting materials for students from different backgrounds?
+[he]
+ברוכים הבאים! אני אלברט, כאן כדי לסייע בקידום כשירות תרבותית בהוראה.
+כיצד אתה מתייחס למגוון בכיתה שלך?
+אילו אתגרים חווית בעת התאמת חומרים לסטודנטים מרקעים שונים?

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI Chat</title>
+    <title>Albert Chatbot</title>
+    <style>
+      body { margin: 0; }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,48 @@
+.chat-container {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-family: Arial, sans-serif;
+}
+.header {
+  padding: 1rem;
+  background: #f5f5f5;
+  text-align: center;
+  font-weight: bold;
+}
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.message {
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  max-width: 80%;
+  word-break: break-word;
+}
+.message.user {
+  align-self: flex-end;
+  background: #dff7c6;
+  font-family: Arial, sans-serif;
+}
+.message.bot {
+  align-self: flex-start;
+  background: #f0f0f0;
+  font-family: "Courier New", serif;
+}
+.input-area {
+  display: flex;
+  padding: 0.5rem;
+  gap: 0.5rem;
+  border-top: 1px solid #ddd;
+}
+.input-area textarea {
+  flex: 1;
+  resize: none;
+  padding: 0.5rem;
+  font-family: Arial, sans-serif;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173
+    port: 5173,
+    proxy: {
+      '/chat': 'http://localhost:3001'
+    }
   }
 });


### PR DESCRIPTION
## Summary
- implement Assistants API backend with Express
- add scenario file and environment examples
- rewrite React frontend for ChatGPT-like UI
- configure Vite dev proxy
- document setup for new environment variables

## Testing
- `npm list openai --depth=0` *(fails: no packages installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845849efb14832ba328450ad4933af2