### PR TITLE
Configure frontend API endpoint via env var

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=https://diversity-bot-1.onrender.com/chat

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -41,7 +41,8 @@ export default function App() {
     setDir(detectDir(userMsg));
     setLoading(true);
     try {
-      const res = await fetch('/chat', {
+      const apiUrl = import.meta.env.VITE_API_URL || '/chat';
+      const res = await fetch(apiUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: userMsg, session_id: sessionIdRef.current })


### PR DESCRIPTION
## Summary
- add `.env.example` for the frontend with `VITE_API_URL`
- use `VITE_API_URL` fallback to `/chat` when sending messages

## Testing
- `npm -C frontend test` *(fails: Missing script)*
- `npm -C backend test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68458dce4598832b9c5603640ef3782b