### PR TITLE
Fix chat route response handling

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -110,10 +110,13 @@ app.post('/chat', async (req, res) => {
       session.scenarioIndex = (session.scenarioIndex + 1) % scenarioList.length;
     }
 
-    res.json({ response: assistantMsg.trim(), session_id });
+    return res.json({ response: assistantMsg.trim(), session_id });
   } catch (err) {
     console.error("❌ Chat error:", err);
-    res.status(500).json({ response: `Internal error: ${err.message}`, session_id });
+    return res.status(500).json({
+      response: "Internal error: " + err.message,
+      session_id,
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
- ensure the chat route returns a JSON response by returning from `res.json` calls
- rewrite catch block to return 500 JSON as specified

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845aa62b758832b8d3c51baead09fdc